### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/tests/unit/test_stripe_direct.py
+++ b/tests/unit/test_stripe_direct.py
@@ -20,7 +20,7 @@ stripe_secret = os.getenv('STRIPE_SECRET_KEY')
 stripe_public = os.getenv('STRIPE_PUBLISHABLE_KEY')
 
 if stripe_secret:
-    print(f"✅ STRIPE_SECRET_KEY: {stripe_secret[:20]}...")
+    print("✅ STRIPE_SECRET_KEY: present (value not shown)")
 else:
     print("❌ STRIPE_SECRET_KEY not found")
 


### PR DESCRIPTION
Potential fix for [https://github.com/hartou/ireti-pos-light-ce/security/code-scanning/8](https://github.com/hartou/ireti-pos-light-ce/security/code-scanning/8)

To fix the problem, we should avoid logging any portion of the sensitive Stripe secret key `STRIPE_SECRET_KEY`. Instead, we should log only whether the environment variable exists (is set), without revealing its value (or any part of it).  
Specifically, in tests/unit/test_stripe_direct.py, replace the line printing the secret value (line 23) with a log that confirms the key is present (e.g., "`STRIPE_SECRET_KEY: present (value not shown)`").  
No new imports or helper methods are needed for this change; just update the print statement. No changes are needed for `STRIPE_PUBLISHABLE_KEY` as it is a public identifier, but reviewing downstream usage of other secrets for leaks may be warranted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
